### PR TITLE
Update clover types

### DIFF
--- a/clover/src/chaintypes.ts
+++ b/clover/src/chaintypes.ts
@@ -18,6 +18,9 @@ const definitions: OverrideBundleDefinition = {
         EcdsaSignature: "[u8; 65]",
         EvmAddress: "H160",
         EthereumTxHash: "H256",
+        BridgeNetworks: {
+          _enum: ["BSC", "Ethereum", "CloverPara"],
+        },
       },
     },
   ],


### PR DESCRIPTION
- Sync clover types with https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/api/spec/clover.ts
- In the future we should be using latest types from that repo. This can be done by using latest on `@polkadot/api` on node but that's a bad idea